### PR TITLE
Bumped Siddhi Version to 4.0.0-alpha

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,12 +122,12 @@
     </dependencyManagement>
 
     <properties>
-        <siddhi.version>4.0.0-M114</siddhi.version>
+        <siddhi.version>4.0.0-alpha</siddhi.version>
         <carbon.transport.version>5.0.1</carbon.transport.version>
         <testng.version>6.8</testng.version>
-        <siddhi.map.json.version>4.0.8</siddhi.map.json.version>
-        <siddhi.map.xml.version>4.0.5</siddhi.map.xml.version>
-        <siddhi.map.text.version>1.0.6</siddhi.map.text.version>
+        <siddhi.map.json.version>4.0.9</siddhi.map.json.version>
+        <siddhi.map.xml.version>4.0.6</siddhi.map.xml.version>
+        <siddhi.map.text.version>1.0.7</siddhi.map.text.version>
         <jacoco.version>0.7.9</jacoco.version>
         <commons-net.version>3.6</commons-net.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## Purpose
> Release the extension with the latest siddhi version.

## Goals
> Bumped Siddhi Version to 4.0.0-alpha.