### PR TITLE
Bump version to 2.x.x

### DIFF
--- a/components/org.wso2.carbon.extension.analytics.publisher.file/pom.xml
+++ b/components/org.wso2.carbon.extension.analytics.publisher.file/pom.xml
@@ -19,13 +19,13 @@
     <parent>
         <groupId>org.wso2.carbon.extension.analytics</groupId>
         <artifactId>analytics-publisher-file</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>bundle</packaging>
     <artifactId>org.wso2.carbon.extension.analytics.publisher.file</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>WSO2 Carbon - Analytics Publisher Library For File</name>
     <url>http://wso2.org</url>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.extension.analytics</groupId>
     <artifactId>analytics-publisher-file</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - Analytics File Publisher</name>
@@ -31,11 +31,11 @@
         <module>features/org.wso2.carbon.extension.analytics.publisher.file.server.feature</module>
     </modules>
     <scm>
-        <url>https://github.com/wso2-extensions/analytics-publisher-file.git</url>
+        <url>https://github.com/wso2-extensions/siddhi-io-file.git</url>
         <developerConnection>
-            scm:git:https://github.com/wso2-extensions/analytics-publisher-file.git
+            scm:git:https://github.com/wso2-extensions/siddhi-io-file.git
         </developerConnection>
-        <connection>scm:git:https://github.com/wso2-extensions/analytics-publisher-file.git
+        <connection>scm:git:https://github.com/wso2-extensions/siddhi-io-file.git
         </connection>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
## Purpose
> To ensure that releases of analytics file publisher and siddhi-io-extension are not getting conflicted.

> Hereafter, analytics file publisher will get released with 2.x.x versions and siddhi-io-file extension will be released with 3.x.x versions.


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
