### PR TITLE
Bump transport-file version with the fix for reading large files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <properties>
         <siddhi.version>5.1.5</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
-        <wso2.transport.file.version>6.0.58</wso2.transport.file.version>
+        <wso2.transport.file.version>6.0.59</wso2.transport.file.version>
         <testng.version>6.8</testng.version>
         <siddhi.map.json.version>5.0.2</siddhi.map.json.version>
         <siddhi.map.xml.version>5.0.2</siddhi.map.xml.version>


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> Fixes in https://github.com/wso2/transport-file/pull/16

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes