### PR TITLE
Add testcases for eof and file.name transport properties

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -73,6 +73,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.siddhi.extension.map.binary</groupId>
+            <artifactId>siddhi-map-binary</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons.wso2</groupId>
             <artifactId>commons-vfs2</artifactId>
         </dependency>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -73,11 +73,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.siddhi.extension.map.binary</groupId>
-            <artifactId>siddhi-map-binary</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons.wso2</groupId>
             <artifactId>commons-vfs2</artifactId>
         </dependency>

--- a/component/src/main/java/io/siddhi/extension/io/file/processors/FileProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/processors/FileProcessor.java
@@ -70,6 +70,8 @@ public class FileProcessor implements CarbonMessageProcessor {
             if (Constants.TEXT_FULL.equalsIgnoreCase(mode)) {
                 if (msg.length() > 0) {
                     carbonCallback.done(carbonMessage);
+                    carbonMessage.setProperty
+                            (org.wso2.transport.file.connector.server.util.Constants.EOF, true);
                     sourceEventListener.onEvent(new String(content, Constants.UTF_8),
                             getRequiredPropertyValues(carbonMessage));
                 }

--- a/component/src/test/resources/files/repo/line/json/logs.txt
+++ b/component/src/test/resources/files/repo/line/json/logs.txt
@@ -3,5 +3,3 @@
 {"event":{"symbol":"WSO2","price":2,"volume":10002}}
 {"event":{"symbol":"WSO2","price":3,"volume":10003}}
 {"event":{"symbol":"WSO2","price":4,"volume":10004}}
-
-

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
                 <version>${siddhi.map.csv.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.siddhi.extension.map.binary</groupId>
+                <artifactId>siddhi-map-binary</artifactId>
+                <version>${siddhi.map.binary.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons.wso2</groupId>
                 <artifactId>commons-vfs2</artifactId>
                 <version>2.0-wso2v15</version>
@@ -145,6 +150,7 @@
         <siddhi.map.xml.version>5.0.2</siddhi.map.xml.version>
         <siddhi.map.text.version>2.0.1</siddhi.map.text.version>
         <siddhi.map.csv.version>2.0.3</siddhi.map.csv.version>
+        <siddhi.map.binary.version>2.0.4</siddhi.map.binary.version>
         <siddhi.execution.list>1.0.0</siddhi.execution.list>
         <jacoco.version>0.7.9</jacoco.version>
         <commons-net.version>3.6</commons-net.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,6 @@
                 <version>${siddhi.map.csv.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.siddhi.extension.map.binary</groupId>
-                <artifactId>siddhi-map-binary</artifactId>
-                <version>${siddhi.map.binary.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons.wso2</groupId>
                 <artifactId>commons-vfs2</artifactId>
                 <version>2.0-wso2v15</version>


### PR DESCRIPTION
## Purpose
> $subject
> bug fix when text_full mode given with eof and file.name transport properties

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes