### PR TITLE
Improvement to read the file header

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
@@ -237,9 +237,9 @@ import java.util.regex.PatternSyntaxException;
                 ),
                 @Parameter(
                         name = "read.only.header",
-                        description = "This parameter used to specify a particular text file (eg: CSV) contains a " +
-                                "header line or not. This can either have value true or false. If it's set to " +
-                                "`true` then an event will throw the header details.",
+                        description = "This parameter used to read only the header or the first line of a particular " +
+                                "text file (eg: CSV). This is only applicable if the mode is LINE. If it's set to " +
+                                "false, the full file content will be read line by line.",
                         optional = true,
                         type = {DataType.BOOL},
                         defaultValue = "false"

--- a/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
@@ -222,7 +222,7 @@ import java.util.regex.PatternSyntaxException;
                 @Parameter(
                         name = "file.read.wait.timeout",
                         description = "This parameter is used to specify the maximum time period (in milliseconds) " +
-                                " till it waits before retrying to read the full file content.",
+                                " till it waits before retrying to read the full file content.\n",
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "1000"
@@ -231,9 +231,19 @@ import java.util.regex.PatternSyntaxException;
                         name = "header.present",
                         description = "This parameter used to specify a particular text file (eg: CSV) contains a " +
                                 "header line or not. This can either have value true or false. If it's set to " +
-                                "`true` then it indicates a file contains a header line, and it will not process",
+                                "`true` then it indicates a file contains a header line, and it will not process.\n",
                         optional = true, defaultValue = "false",
-                        type = {DataType.BOOL})
+                        type = {DataType.BOOL}
+                ),
+                @Parameter(
+                        name = "read.only.header",
+                        description = "This parameter used to specify a particular text file (eg: CSV) contains a " +
+                                "header line or not. This can either have value true or false. If it's set to " +
+                                "`true` then an event will throw the header details.",
+                        optional = true,
+                        type = {DataType.BOOL},
+                        defaultValue = "false"
+                ),
         },
         examples = {
                 @Example(
@@ -329,6 +339,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
     private ScheduledFuture scheduledFuture;
     private ConnectionCallback connectionCallback;
     private String headerPresent;
+    private String readOnlyHeader;
 
     @Override
     protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {
@@ -440,6 +451,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
         endRegex = optionHolder.validateAndGetStaticValue(Constants.END_REGEX, null);
         fileReadWaitTimeout = optionHolder.validateAndGetStaticValue(Constants.FILE_READ_WAIT_TIMEOUT, "1000");
         headerPresent = optionHolder.validateAndGetStaticValue(Constants.HEADER_PRESENT, "false");
+        readOnlyHeader = optionHolder.validateAndGetStaticValue(Constants.READ_ONLY_HEADER, "false");
         validateParameters();
         createInitialSourceConf();
         updateSourceConf();
@@ -519,6 +531,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
         fileSourceConfiguration.setTimeout(timeout);
         fileSourceConfiguration.setFileReadWaitTimeout(fileReadWaitTimeout);
         fileSourceConfiguration.setHeaderPresent(headerPresent);
+        fileSourceConfiguration.setReadOnlyHeader(readOnlyHeader);
     }
 
     private void updateSourceConf() {
@@ -632,6 +645,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
             properties.put(Constants.MAX_LINES_PER_POLL, "10");
             properties.put(Constants.POLLING_INTERVAL, filePollingInterval);
             properties.put(Constants.HEADER_PRESENT, headerPresent);
+            properties.put(Constants.READ_ONLY_HEADER, readOnlyHeader);
             if (actionAfterFailure != null) {
                 properties.put(Constants.ACTION_AFTER_FAILURE_KEY, actionAfterFailure);
             }
@@ -670,6 +684,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
                 properties.put(Constants.ACK_TIME_OUT, "1000");
                 properties.put(Constants.MODE, mode);
                 properties.put(Constants.HEADER_PRESENT, headerPresent);
+                properties.put(Constants.READ_ONLY_HEADER, readOnlyHeader);
                 VFSClientConnector vfsClientConnector = new VFSClientConnector();
                 FileProcessor fileProcessor = new FileProcessor(sourceEventListener, fileSourceConfiguration);
                 vfsClientConnector.setMessageProcessor(fileProcessor);

--- a/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
@@ -233,7 +233,7 @@ import java.util.regex.PatternSyntaxException;
                                 "header line or not. This can either have value true or false. If it's set to " +
                                 "`true` then it indicates a file contains a header line, and it will not process",
                         optional = true, defaultValue = "false",
-                        type = {DataType.BOOL}),
+                        type = {DataType.BOOL})
         },
         examples = {
                 @Example(

--- a/component/src/main/java/io/siddhi/extension/io/file/listeners/FileSystemListener.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/listeners/FileSystemListener.java
@@ -144,6 +144,7 @@ public class FileSystemListener implements RemoteFileSystemListener {
                             fileSourceConfiguration.getFileReadWaitTimeout());
                     properties.put(Constants.MODE, mode);
                     properties.put(Constants.HEADER_PRESENT, fileSourceConfiguration.getHeaderPresent());
+                    properties.put(Constants.READ_ONLY_HEADER, fileSourceConfiguration.getReadOnlyHeader());
                     if (fileSourceConfiguration.isTailingEnabled()) {
                         fileSourceConfiguration.setTailedFileURI(fileURI);
                         if (fileSourceConfiguration.getTailedFileURIMap().contains(fileURI)) {
@@ -204,7 +205,8 @@ public class FileSystemListener implements RemoteFileSystemListener {
     }
 
     @Override
-    public void done() {}
+    public void done() {
+    }
 
     static class FileServerExecutor implements Runnable {
         ServerConnector fileServerConnector = null;

--- a/component/src/main/java/io/siddhi/extension/io/file/util/Constants.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/util/Constants.java
@@ -20,9 +20,11 @@ package io.siddhi.extension.io.file.util;
 
 /**
  * Constants used in siddhi-io-file extension.
- * */
+ */
 public class Constants {
-    private Constants(){}
+    private Constants() {
+    }
+
     /* configuration parameters*/
     public static final String URI = "uri";
     public static final String PATH = "path";
@@ -48,6 +50,7 @@ public class Constants {
     public static final String FILE_READ_WAIT_TIMEOUT = "file.read.wait.timeout";
     public static final int WAIT_TILL_DONE = 5000;
     public static final String HEADER_PRESENT = "header.present";
+    public static final String READ_ONLY_HEADER = "read.only.header";
 
     /* configuration param values*/
     public static final String MOVE = "move";

--- a/component/src/main/java/io/siddhi/extension/io/file/util/FileSourceConfiguration.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/util/FileSourceConfiguration.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 
 /**
  * Class for keep the configurations of a file source instance.
- * */
+ */
 public class FileSourceConfiguration {
 
     private boolean isTailingEnabled;
@@ -42,6 +42,7 @@ public class FileSourceConfiguration {
     private String protocolForMoveAfterProcess = null;
     private long timeout = 5000;
     private String headerPresent = "false";
+    private String readOnlyHeader = "false";
 
     private FileServerConnector fileServerConnector;
     private RemoteFileSystemServerConnector fileSystemServerConnector;
@@ -249,5 +250,13 @@ public class FileSourceConfiguration {
 
     public void setHeaderPresent(String headerPresent) {
         this.headerPresent = headerPresent;
+    }
+
+    public String getReadOnlyHeader() {
+        return readOnlyHeader;
+    }
+
+    public void setReadOnlyHeader(String readOnlyHeader) {
+        this.readOnlyHeader = readOnlyHeader;
     }
 }

--- a/component/src/test/java/io/siddhi/extension/io/file/FileSourceLineModeTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/file/FileSourceLineModeTestCase.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Test cases for siddhi-io-file source.
  * mode = line.
- * */
+ */
 public class FileSourceLineModeTestCase {
     private static final Logger log = Logger.getLogger(FileSourceLineModeTestCase.class);
     private AtomicInteger count = new AtomicInteger();
@@ -62,6 +62,7 @@ public class FileSourceLineModeTestCase {
         newRoot = new File(dirUri);
         moveAfterProcessDir = rootPath + "/moved_files";
     }
+
     @BeforeMethod
     public void doBeforeMethod() {
         count.set(0);
@@ -76,6 +77,7 @@ public class FileSourceLineModeTestCase {
                     " which are required for tests. Hence aborting tests.", e);
         }
     }
+
     @AfterMethod
     public void doAfterMethod() {
         try {
@@ -148,7 +150,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest1")
+    @Test(dependsOnMethods = "siddhiIoFileTest1")
     public void siddhiIoFileTest2() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 2");
         String streams = "" +
@@ -208,7 +210,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest2")
+    @Test(dependsOnMethods = "siddhiIoFileTest2")
     public void siddhiIoFileTest3() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 3");
         String streams = "" +
@@ -293,9 +295,9 @@ public class FileSourceLineModeTestCase {
                     bufferedWriter.newLine();
                     bufferedWriter.flush();
                     bufferedWriter.close();
-                    } catch (IOException e) {
-                        log.error(e.getMessage());
-                    }
+                } catch (IOException e) {
+                    log.error(e.getMessage());
+                }
             }
         });
         t2.start();
@@ -304,6 +306,7 @@ public class FileSourceLineModeTestCase {
         AssertJUnit.assertEquals("Number of events", 7, count.get());
         siddhiAppRuntime.shutdown();
     }
+
     @Test(dependsOnMethods = "siddhiIoFileTest3")
     public void siddhiIoFileTest4() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 4");
@@ -519,7 +522,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest7")
+    @Test(dependsOnMethods = "siddhiIoFileTest7")
     public void siddhiIoFileTest8() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 8");
         String streams = "" +
@@ -602,7 +605,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest9")
+    @Test(dependsOnMethods = "siddhiIoFileTest9")
     public void siddhiIoFileTest10() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 10");
         String streams = "" +
@@ -659,7 +662,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest10")
+    @Test(dependsOnMethods = "siddhiIoFileTest10")
     public void siddhiIoFileTest11() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 11");
         String streams = "" +
@@ -719,7 +722,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest11")
+    @Test(dependsOnMethods = "siddhiIoFileTest11")
     public void siddhiIoFileTest12() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 12");
         String streams = "" +
@@ -873,7 +876,7 @@ public class FileSourceLineModeTestCase {
         siddhiAppRuntime.shutdown();
     }
 
-    @Test (dependsOnMethods = "siddhiIoFileTest12")
+    @Test(dependsOnMethods = "siddhiIoFileTest12")
     public void siddhiIoFileTest14() throws InterruptedException {
         log.info("test SiddhiIoFile [mode=line] Test 14");
         String streams = "" +
@@ -1104,8 +1107,8 @@ public class FileSourceLineModeTestCase {
                 "action.after.process='delete', " +
                 "tailing='false', " +
                 "@map(type='json', enclosing.element=\"$.event\", " +
-                    "@attributes(symbol = \"symbol\", price = \"price\", volume = \"volume\", " +
-                        "eof = 'trp:eof', fp = 'trp:file.path')))\n" +
+                "@attributes(symbol = \"symbol\", price = \"price\", volume = \"volume\", " +
+                "eof = 'trp:eof', fp = 'trp:file.path')))\n" +
                 "define stream FooStream (symbol string, price float, volume long, eof String, fp String); " +
                 "define stream BarStream (symbol string, price float, volume long, eof String, fp String); ";
         String query = "" +
@@ -1143,17 +1146,17 @@ public class FileSourceLineModeTestCase {
         String streams = "" +
                 "@App:name('TestSiddhiApp')" +
                 "@source(type='file', mode='line'," +
-                    "file.uri='file:" + newRoot + "/line/header/test.txt', " +
-                    "header.present='true'," +
-                    "action.after.process='delete', " +
-                    "tailing='false', " +
-                    "@map( type='csv', delimiter='|', " +
-                        "@attributes(code = '0', serialNo = '1', amount = '2', fileName = 'trp:file.path', " +
-                                    "eof = 'trp:eof')))\n" +
+                "file.uri='file:" + newRoot + "/line/header/test.txt', " +
+                "header.present='true'," +
+                "action.after.process='delete', " +
+                "tailing='false', " +
+                "@map( type='csv', delimiter='|', " +
+                "@attributes(code = '0', serialNo = '1', amount = '2', fileName = 'trp:file.path', " +
+                "eof = 'trp:eof')))\n" +
                 "define stream FileReaderStream (code string, serialNo string, amount double, " +
-                    "fileName string, eof string); " +
+                "fileName string, eof string); " +
                 "define stream FileResultStream (code string, serialNo string, amount double, " +
-                    "fileName string, eof string); ";
+                "fileName string, eof string); ";
         String query = "" +
                 "from FileReaderStream " +
                 "select * " +
@@ -1256,6 +1259,66 @@ public class FileSourceLineModeTestCase {
         AssertJUnit.assertEquals(1, file.list().length);
         //assert event count
         AssertJUnit.assertEquals("Number of events", 3, count.get());
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void siddhiIOFileTestForSkipReadOnlyHeader() throws InterruptedException {
+        log.info("test SiddhiIOFile read.only.header=false parameter Test");
+        String streams = "" +
+                "@App:name('TestSiddhiApp')\n" +
+                "@source(type='file', mode='line', file.uri='file:" + newRoot + "/line/header/test.txt', " +
+                "read.only.header='false', tailing='false', " +
+                "@map(type='csv', delimiter='|'))\n" +
+                "define stream FileReaderStream (code string, serialNo string, amount string);\n" +
+                "@sink(type='log')\n" +
+                "define stream FileResultStream (code string, serialNo string, amount string);\n";
+
+        String query = "" +
+                "from FileReaderStream\n" +
+                "select *\n" +
+                "insert into FileResultStream;";
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("FileResultStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                count.incrementAndGet();
+            }
+        });
+        siddhiAppRuntime.start();
+        SiddhiTestHelper.waitForEvents(100, 7, count.get(), 6000);
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void siddhiIOFileTestForReadOnlyHeader() throws InterruptedException {
+        log.info("test SiddhiIOFile read.only.header parameter Test");
+        String streams = "" +
+                "@App:name('TestSiddhiApp')\n" +
+                "@source(type='file', mode='line', file.uri='file:" + newRoot + "/line/header/test.txt', " +
+                "read.only.header='true', action.after.process='keep', tailing='false', \n" +
+                "@map(type='csv', delimiter='|'))\n" +
+                "define stream FileReaderStream (code string, serialNo string, amount string);\n" +
+                "@sink(type='log')\n" +
+                "define stream FileResultStream (code string, serialNo string, amount string);\n";
+
+        String query = "" +
+                "from FileReaderStream\n" +
+                "select *\n" +
+                "insert into FileResultStream;";
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("FileResultStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                count.incrementAndGet();
+            }
+        });
+        siddhiAppRuntime.start();
+        SiddhiTestHelper.waitForEvents(100, 1, count.get(), 3000);
         siddhiAppRuntime.shutdown();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <properties>
         <siddhi.version>5.1.5</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
-        <wso2.transport.file.version>6.0.63</wso2.transport.file.version>
+        <wso2.transport.file.version>6.0.65</wso2.transport.file.version>
         <org.apache.commons-compress.version>1.19</org.apache.commons-compress.version>
         <testng.version>6.8</testng.version>
         <siddhi.map.json.version>5.0.2</siddhi.map.json.version>


### PR DESCRIPTION
## Purpose
> The read.only.header is a new parameter used to get the header details of a file which contains event. if the value is set to true it will throw event with header detail. Else it will continue it process.
FIxes : https://github.com/siddhi-io/siddhi-io-file/issues/88

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes