### PR TITLE
Add Support for file name patterns in source

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
@@ -288,6 +288,14 @@ import static org.quartz.CronExpression.isValidExpression;
                         optional = true,
                         type = {DataType.STRING},
                         defaultValue = "None"
+                ),
+                @Parameter(
+                        name = Constants.FILE_NAME_PATTERN,
+                        description = "Regex pattern for the filenames that should be read from the directory. " +
+                                "Note: This parameter is applicable only if the connector is reading from a directory",
+                        optional = true,
+                        type = {DataType.STRING},
+                        defaultValue = "None"
                 )
         },
         examples = {
@@ -389,6 +397,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
     private String bufferSizeInBinaryChunked;
     private SourceMetrics metrics;
     private String cronExpression;
+    private String fileNamePattern;
 
     @Override
     protected ServiceDeploymentInfo exposeServiceDeploymentInfo() {
@@ -508,6 +517,8 @@ public class FileSource extends Source<FileSource.FileSourceState> {
         readOnlyHeader = optionHolder.validateAndGetStaticValue(Constants.READ_ONLY_HEADER, "false");
         bufferSizeInBinaryChunked = optionHolder.validateAndGetStaticValue(Constants.BUFFER_SIZE_IN_BINARY_CHUNKED,
                 "65536");
+        fileNamePattern = optionHolder.validateAndGetStaticValue(Constants.FILE_NAME_PATTERN, null);
+
         if (optionHolder.isOptionExists(Constants.CRON_EXPRESSION)) {
             cronExpression = optionHolder.validateAndGetStaticValue(Constants.CRON_EXPRESSION, null);
             if (!isValidExpression(cronExpression)) {
@@ -643,6 +654,7 @@ public class FileSource extends Source<FileSource.FileSourceState> {
         map.put(Constants.FILE_READ_WAIT_TIMEOUT_KEY, fileReadWaitTimeout);
         map.put(Constants.BUFFER_SIZE_IN_BINARY_CHUNKED, bufferSizeInBinaryChunked);
         map.put(Constants.CRON_EXPRESSION, cronExpression);
+        map.put(Constants.FILE_NAME_PATTERN_PROPERTY_NAME, fileNamePattern);
 
         if (Constants.BINARY_FULL.equalsIgnoreCase(mode) ||
                 Constants.TEXT_FULL.equalsIgnoreCase(mode) || Constants.BINARY_CHUNKED.equalsIgnoreCase(mode)) {

--- a/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
@@ -295,7 +295,7 @@ import static org.quartz.CronExpression.isValidExpression;
                                 "Note: This parameter is applicable only if the connector is reading from a directory",
                         optional = true,
                         type = {DataType.STRING},
-                        defaultValue = "None"
+                        defaultValue = "<Empty_String>"
                 )
         },
         examples = {

--- a/component/src/main/java/io/siddhi/extension/io/file/util/Constants.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/util/Constants.java
@@ -50,6 +50,8 @@ public class Constants {
     public static final String HEADER_PRESENT = "header.present";
     public static final String READ_ONLY_HEADER = "read.only.header";
     public static final String CRON_EXPRESSION = "cron.expression";
+    public static final String FILE_NAME_PATTERN = "file.name.pattern";
+    public static final String FILE_NAME_PATTERN_PROPERTY_NAME = "fileNamePattern";
 
     /* configuration param values*/
     public static final String MOVE = "move";

--- a/component/src/test/java/io/siddhi/extension/io/file/FileHandlingTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/file/FileHandlingTestCase.java
@@ -235,7 +235,8 @@ public class FileHandlingTestCase {
         File currentFile = new File(newRoot + "/destination.txt");
         File newFile = new File(newRoot + "/changedDestination.txt");
         String app = "" +
-                "@App:name('TestFileEventListener') @source(type='fileeventlistener', " +
+                "@App:name('TestFileEventListener') " +
+                "@source(type='fileeventlistener', " +
                 "dir.uri='" + newRoot + "')\n" +
                 "define stream FileListenerStream (filepath string, filename string, status string); \n" +
                 "@sink(type='log')" +

--- a/component/src/test/resources/files/repo/name_pattern/test
+++ b/component/src/test/resources/files/repo/name_pattern/test
@@ -1,0 +1,1 @@
+{"event":{"symbol":"WSO2","price":0,"volume":10000}}

--- a/component/src/test/resources/files/repo/name_pattern/test-1
+++ b/component/src/test/resources/files/repo/name_pattern/test-1
@@ -1,0 +1,1 @@
+{"event":{"symbol":"WSO2","price":1,"volume":10000}}

--- a/component/src/test/resources/files/repo/name_pattern/test-2
+++ b/component/src/test/resources/files/repo/name_pattern/test-2
@@ -1,0 +1,1 @@
+{"event":{"symbol":"WSO2","price":2,"volume":10000}}


### PR DESCRIPTION
## Purpose
This PR adds support for using file name patterns using regex in the Source extension

## Approach
transport-file implementation already supports file name patterns using regex when reading from a directory. This PR will introduce a new parameter `file.name.pattern` which will take input of a regex expression which then will be used to initialize the FileSystemServerConnector


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK v1.8.0_211
 
