### PR TITLE
Fix for https://github.com/wso2/streaming-integrator/issues/165

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/file/FileCopyExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/file/FileCopyExtension.java
@@ -177,7 +177,9 @@ public class FileCopyExtension extends StreamFunctionProcessor {
 
     @Override
     public List<Attribute> getReturnAttributes() {
-        return new ArrayList<>();
+        List<Attribute> attributes = new ArrayList<>();
+        attributes.add(new Attribute("isSuccess", Attribute.Type.BOOL));
+        return attributes;
     }
 
     @Override
@@ -236,7 +238,7 @@ public class FileCopyExtension extends StreamFunctionProcessor {
                 }
             }
         }
-        return new Object[0];
+        return new Object[]{true};
     }
 
     @Override

--- a/component/src/main/java/io/siddhi/extension/execution/file/FileMoveExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/file/FileMoveExtension.java
@@ -175,7 +175,9 @@ public class FileMoveExtension extends StreamFunctionProcessor {
 
     @Override
     public List<Attribute> getReturnAttributes() {
-        return new ArrayList<>();
+        List<Attribute> attributes = new ArrayList<>();
+        attributes.add(new Attribute("isSuccess", Attribute.Type.BOOL));
+        return attributes;
     }
 
     @Override
@@ -230,7 +232,7 @@ public class FileMoveExtension extends StreamFunctionProcessor {
             throw new SiddhiAppRuntimeException("Exception occurred when getting the file type " +
                     uri, e);
         }
-        return new Object[0];
+        return new Object[]{true};
     }
 
     @Override

--- a/component/src/test/java/io/siddhi/extension/io/file/FileFunctionsTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/io/file/FileFunctionsTestCase.java
@@ -97,6 +97,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }
@@ -120,7 +121,7 @@ public class FileFunctionsTestCase {
                 "define stream CopyFileStream(sample string);\n" +
                 "from CopyFileStream#file:copy" +
                 "('" + sourceRoot + "/archive', '" + sourceRoot + "/destination', '', " + false + ")\n" +
-                "select *\n" +
+                "select sample, isSuccess \n" +
                 "insert into ResultStream;";
         SiddhiManager siddhiManager = new SiddhiManager();
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(app);
@@ -134,6 +135,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }
@@ -171,6 +173,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }
@@ -208,6 +211,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }
@@ -674,7 +678,7 @@ public class FileFunctionsTestCase {
                 "define stream MoveFileStream(sample string);\n" +
                 "from MoveFileStream" +
                 "#file:move('" + tempSource + "/archive/', '" + sourceRoot + "/destination', '')\n" +
-                "select * \n" +
+                "select sample, isSuccess \n" +
                 "insert into ResultStream;";
         SiddhiManager siddhiManager = new SiddhiManager();
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(app);
@@ -688,6 +692,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }
@@ -726,6 +731,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }
@@ -832,6 +838,7 @@ public class FileFunctionsTestCase {
                 for (Event event : events) {
                     if (n == 0) {
                         AssertJUnit.assertEquals("WSO2", event.getData(0));
+                        AssertJUnit.assertEquals(true, event.getData(1));
                     } else {
                         AssertJUnit.fail("More events received than expected.");
                     }


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/streaming-integrator/issues/165

## Release note
- Return attributes in file:move() and file:copy() stream functions were not working. This issue is now fixed. Refer: https://github.com/wso2/streaming-integrator/issues/165

## Automation tests
 - Unit tests available.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes