### PR TITLE
Make regex matching dynamic in copy function

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/file/FileCopyExtension.java
+++ b/component/src/main/java/io/siddhi/extension/execution/file/FileCopyExtension.java
@@ -74,6 +74,7 @@ import java.util.regex.Pattern;
                                 "Note: Add an empty string to match all files",
                         type = DataType.STRING,
                         optional = true,
+                        dynamic = true,
                         defaultValue = "<Empty_String>"
                 ),
                 @Parameter(
@@ -193,7 +194,7 @@ public class FileCopyExtension extends StreamFunctionProcessor {
         String destinationDirUri = (String) data[1];
         String regex = "";
         boolean excludeRootFolder = false;
-        if (inputExecutorLength == 3) {
+        if (inputExecutorLength >= 3) {
             regex = (String) data[2];
         }
         if (pattern == null) {

--- a/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/FileSource.java
@@ -491,10 +491,14 @@ public class FileSource extends Source<FileSource.FileSourceState> {
             tailing = optionHolder.validateAndGetStaticValue(Constants.TAILING, Constants.TRUE);
         }
         isTailingEnabled = Boolean.parseBoolean(tailing);
-
+        readOnlyHeader = optionHolder.validateAndGetStaticValue(Constants.READ_ONLY_HEADER, "false");
         if (isTailingEnabled) {
             actionAfterProcess = optionHolder.validateAndGetStaticValue(Constants.ACTION_AFTER_PROCESS,
                     Constants.NONE);
+            if (Boolean.parseBoolean(readOnlyHeader)) {
+                throw new SiddhiAppCreationException("Either 'tailing' or 'read.only.header' should be true. But both of them" +
+                        "set to 'true'.");
+            }
         } else {
             actionAfterProcess = optionHolder.validateAndGetStaticValue(Constants.ACTION_AFTER_PROCESS,
                     Constants.KEEP);
@@ -526,7 +530,6 @@ public class FileSource extends Source<FileSource.FileSourceState> {
         endRegex = optionHolder.validateAndGetStaticValue(Constants.END_REGEX, null);
         fileReadWaitTimeout = optionHolder.validateAndGetStaticValue(Constants.FILE_READ_WAIT_TIMEOUT, "1000");
         headerPresent = optionHolder.validateAndGetStaticValue(Constants.HEADER_PRESENT, "false");
-        readOnlyHeader = optionHolder.validateAndGetStaticValue(Constants.READ_ONLY_HEADER, "false");
         bufferSizeInBinaryChunked = optionHolder.validateAndGetStaticValue(Constants.BUFFER_SIZE_IN_BINARY_CHUNKED,
                 "65536");
         fileNamePattern = optionHolder.validateAndGetStaticValue(Constants.FILE_NAME_PATTERN, null);


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> To enable dynamic regexs to execute when copying files

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes