### PR TITLE
Add support to skip multi-line headers

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/file/util/Constants.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/util/Constants.java
@@ -49,6 +49,7 @@ public class Constants {
     public static final String FILE_READ_WAIT_TIMEOUT = "file.read.wait.timeout";
     public static final int WAIT_TILL_DONE = 5000;
     public static final String HEADER_PRESENT = "header.present";
+    public static final String HEADER_LINE_COUNT = "header.line.count";
     public static final String READ_ONLY_HEADER = "read.only.header";
     public static final String READ_ONLY_TRAILER = "read.only.trailer";
     public static final String SKIP_TRAILER = "skip.trailer";

--- a/component/src/main/java/io/siddhi/extension/io/file/util/FileSourceConfiguration.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/util/FileSourceConfiguration.java
@@ -43,6 +43,7 @@ public class FileSourceConfiguration {
     private String protocolForMoveAfterProcess = null;
     private long timeout = 5000;
     private String headerPresent = "false";
+    private int headerLineCount = 1;
     private String readOnlyHeader = "false";
     private String readOnlyTrailer = "false";
     private String skipTrailer = "false";
@@ -262,6 +263,14 @@ public class FileSourceConfiguration {
 
     public void setHeaderPresent(String headerPresent) {
         this.headerPresent = headerPresent;
+    }
+
+    public int getHeaderLineCount() {
+        return headerLineCount;
+    }
+
+    public void setHeaderLineCount(int headerLineCount) {
+        this.headerLineCount = headerLineCount;
     }
 
     public String getCurrentlyReadingFileURI() {

--- a/component/src/main/java/io/siddhi/extension/io/file/util/Util.java
+++ b/component/src/main/java/io/siddhi/extension/io/file/util/Util.java
@@ -121,6 +121,7 @@ public class Util {
                     fileSourceConfiguration.getFileReadWaitTimeout());
             properties.put(Constants.MODE, mode);
             properties.put(Constants.HEADER_PRESENT, fileSourceConfiguration.getHeaderPresent());
+            properties.put(Constants.HEADER_LINE_COUNT, Integer.toString(fileSourceConfiguration.getHeaderLineCount()));
             properties.put(Constants.READ_ONLY_HEADER, fileSourceConfiguration.getReadOnlyHeader());
             properties.put(Constants.READ_ONLY_TRAILER, fileSourceConfiguration.getReadOnlyTrailer());
             properties.put(Constants.SKIP_TRAILER, fileSourceConfiguration.getSkipTrailer());

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
     <properties>
         <siddhi.version>5.1.26</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
-        <wso2.transport.file.version>6.1.4</wso2.transport.file.version>
+        <wso2.transport.file.version>6.1.5</wso2.transport.file.version>
         <org.apache.commons-compress.version>1.19</org.apache.commons-compress.version>
         <testng.version>6.8</testng.version>
         <siddhi.map.json.version>5.2.2</siddhi.map.json.version>


### PR DESCRIPTION
## Purpose
`Transport-file` support ignoring the file header line by setting the `header.present` parameter to `true`. But this only ignores the first line of the file. This needs to be modified to cater to files with multi-line headers.

Fixes https://github.com/wso2/api-manager/issues/2056

## Approach
A new parameter, `header.line.count` is introduced to specify the number of header lines to ignore. This needs to be used along with the parameter, `header.present='true'`. The default value is `1`.

Ex:
```
@source(type='file', 
    mode='line',
    dir.uri='file:/artifacts/source_dir/',
    action.after.process='move',
    tailing='false',
    move.after.process='file:/artifacts/dest_dir',
    header.present='true',
    header.line.count='3',
    @map(type='csv'))
define stream InputStream (msg string);
```

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
- https://github.com/wso2/transport-file/pull/33