### PR TITLE
Bump trasport.file.version to 6.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
     <properties>
         <siddhi.version>5.1.26</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
-        <wso2.transport.file.version>6.1.5</wso2.transport.file.version>
+        <wso2.transport.file.version>6.1.6</wso2.transport.file.version>
         <org.apache.commons-compress.version>1.19</org.apache.commons-compress.version>
         <testng.version>6.8</testng.version>
         <siddhi.map.json.version>5.2.2</siddhi.map.json.version>


### PR DESCRIPTION
Bump the trasport.file.version from 6.1.5 to 6.1.6

Resolves: https://github.com/wso2-enterprise/wso2-apim-internal/issues/5594